### PR TITLE
配列とオブジェクトの古い記法についての記述を更新

### DIFF
--- a/docs/en/guides/get-started.md
+++ b/docs/en/guides/get-started.md
@@ -49,8 +49,8 @@ this is a multi-line comment
 | String      | `str`     | `"kawaii"`                     |
 | Number      | `num`     | `42`                           |
 | Boolean     | `bool`    | `true` / `false`               |
-| Array       | `arr`     | `["ai" "chan" "cute"]`         |
-| Object      | `obj`     | `{ foo: "bar"; a: 42; }`       |
+| Array       | `arr`     | `["ai", "chan", "cute"]`         |
+| Object      | `obj`     | `{ foo: "bar", a: 42 }`       |
 | Null        | `null`    | `null`                         |
 | Function    | `fn`      | `@(x) { x }`                   |
 | Error       | `error`   | *(TODO)*                       |
@@ -92,7 +92,7 @@ print(message)
 
 ## Arrays
 
-Declare arrays by listing expressions within `[]`, separated by spaces:
+Declare arrays by listing expressions within `[]`, separated by `,`:
 
 ```aiscript
 ["ai", "chan", "kawaii"]
@@ -110,7 +110,7 @@ let arr = ["ai", "chan", "kawaii"]
 
 Objects in AiScript are similar to associative arrays with string-only keys. Each element consists of a key and a value, called a **property**. 
 
-Write properties within `{}`, separated by `,`, `;`, or whitespace. Use `:` to separate keys and values:
+Write properties within `{}`, separated by `,` or newlines. Use `:` to separate keys and values:
 
 ```aiscript
 {

--- a/docs/ja/guides/get-started.md
+++ b/docs/ja/guides/get-started.md
@@ -47,8 +47,8 @@ this is a comment
 	<tr><td>文字列</td><td><code>str</code></td><td><code>"kawaii"</code></td></tr>
 	<tr><td>数値</td><td><code>num</code></td><td><code>42</code></td></tr>
 	<tr><td>真理値</td><td><code>bool</code></td><td><code>true</code>/<code>false</code></td></tr>
-	<tr><td>配列</td><td><code>arr</code></td><td><code>["ai" "chan" "cute"]</code></td></tr>
-	<tr><td>オブジェクト</td><td><code>obj</code></td><td><code>{ foo: "bar"; a: 42; }</code></td></tr>
+	<tr><td>配列</td><td><code>arr</code></td><td><code>["ai", "chan", "cute"]</code></td></tr>
+	<tr><td>オブジェクト</td><td><code>obj</code></td><td><code>{ foo: "bar", a: 42 }</code></td></tr>
 	<tr><td>null</td><td><code>null</code></td><td><code>null</code></td></tr>
 	<tr><td>関数</td><td><code>fn</code></td><td><code>@(x) { x }</code></td></tr>
 	<tr><td>エラー</td><td><code>error</code></td><td><code>(TODO)</code></td></tr>
@@ -84,7 +84,7 @@ print(message)
 ```
 
 ## 配列
-`[]`の中に式をスペースで区切って列挙します。
+`[]`の中に式を`,`で区切って列挙します。
 ```aiscript
 ["ai", "chan", "kawaii"]
 ```
@@ -101,7 +101,7 @@ let arr = ["ai", "chan", "kawaii"]
 AiScriptにおけるオブジェクトは文字列のみをキーとした連想配列のようなものとなっています。  
 キーと値から構成される各要素をプロパティと呼びます。  
 この時キーをプロパティ名と呼びます。  
-`{}`の中にプロパティを`,`/`;`/空白で区切って列挙します。
+`{}`の中にプロパティを`,`か改行で区切って列挙します。
 プロパティ名と値は`: `で区切ります。
 ```aiscript
 {


### PR DESCRIPTION
get-started.md に配列の空白区切りやオブジェクトのセミコロン区切りが現在も使用できるような記述があったので、1.0以降の記法に合わせて更新しました。