### PR TITLE
不要なセミコロンを削除

### DIFF
--- a/docs/en/references/std.md
+++ b/docs/en/references/std.md
@@ -178,7 +178,7 @@ Returns an array of object values.
 #### @Obj:kvs(_v_: obj): arr
 Returns an array of object keys, values, and key/value pairs.
 
-#### @Obj:from_kvs(_kvs_: arr): obj;
+#### @Obj:from_kvs(_kvs_: arr): obj
 Creates an object from key/value pairs. (Available from v1.2.0 or later)
 
 #### @Obj:get&lt;T&gt;(_v_: obj&lt;T&gt;, _key_: str): T

--- a/docs/ja/references/std.md
+++ b/docs/ja/references/std.md
@@ -180,7 +180,7 @@ encoded_text をエンコードされたURI構成要素としてデコードし�
 #### @Obj:kvs(_v_: obj): arr
 オブジェクトのキー、値、キーと値の組を配列にして返します。
 
-#### @Obj:from_kvs(_kvs_: arr): obj;
+#### @Obj:from_kvs(_kvs_: arr): obj
 キーと値の組の配列からオブジェクトを作成して返します。（v1.2.0以降で使用可能）
 
 #### @Obj:get&lt;T&gt;(_v_: obj&lt;T&gt;, _key_: str): T


### PR DESCRIPTION
[`Obj:from_kvs`](https://aiscript-dev.github.io/references/std.html#obj-from-kvs-kvs-arr-obj) の見出しだけ末尾にセミコロンがついていたので削除しました。